### PR TITLE
Update build dependency for cdt.

### DIFF
--- a/pipeline.jsonc
+++ b/pipeline.jsonc
@@ -5,7 +5,7 @@
         "dependencies": // dependencies to pull for a build of contracts, by branch, tag, or commit hash
         {
             "eosio": "develop", 
-            "eosio.cdt": "f7529f9d6c093e9ad0067cfd8d393d472009f50a"
+            "eosio.cdt": "v1.8.0-rc1"
         }
     }
 }


### PR DESCRIPTION
The current eosio.cdt reference doesn't pass the version requirements in the cmake configuration. Updating to a compatible version by tag.

Resolves:
```
CMake Error at CMakeLists.txt:38 (message):
--
  | Found eosio.cdt version 1.7.0-develop but it does not satisfy version
  | requirements: version '1.7.0-develop' does not meet hard minimum version
  | requirement of 1.8
  |  
  | Please use eosio.cdt version 1.8.x
```